### PR TITLE
Kwparams

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 def main():
     setup(
         name='stcrestclient',
-        version= '1.5.3',
+        version= '1.5.4',
         author='Andrew Gillis',
         author_email='andrew.gillis@spirent.com',
         url='https://github.com/Spirent/py-stcrestclient',

--- a/stcrestclient/resthttp.py
+++ b/stcrestclient/resthttp.py
@@ -202,8 +202,7 @@ class RestHttp(object):
 
         return self._handle_response(rsp, to_lower)
 
-    def post_request(self, container, resource=None, params=None,
-                     accept=None):
+    def post_request(self, container, resource=None, params=None, accept=None):
         """Send a POST request."""
         url = self.make_url(container, resource)
         headers = self._make_headers(accept)
@@ -219,8 +218,7 @@ class RestHttp(object):
 
         return self._handle_response(rsp)
 
-    def put_request(self, container, resource=None, params=None,
-                    accept=None):
+    def put_request(self, container, resource=None, params=None, accept=None):
         """Send a PUT request."""
         url = self.make_url(container, resource)
         headers = self._make_headers(accept)
@@ -257,8 +255,8 @@ class RestHttp(object):
 
         return self._handle_response(rsp)
 
-    def download_file(self, container, resource, save_path=None,
-                      accept=None, query_items=None):
+    def download_file(self, container, resource, save_path=None, accept=None,
+                      query_items=None):
         """Download a file."""
         url = self.make_url(container, resource)
         if not save_path:

--- a/stcrestclient/stchttp.py
+++ b/stcrestclient/stchttp.py
@@ -335,28 +335,30 @@ class StcHttp(object):
         status, data = self._rest.get_request('objects', str(handle), args)
         return data
 
-    def create(self, object_type, under=None, attributes=None):
+    def create(self, object_type, under=None, attributes=None, **kwattrs):
         """Create a new automation object.
 
         Arguments:
         object_type -- Type of object to create.
         under       -- Handle of the parent of the new object.
         attributes  -- Dictionary of attributes (name-value pairs).
+        kwattrs     -- Optional keyword attributes (name=value pairs).
 
         Return:
         Handle of newly created object.
 
         """
-        data = self.createx(object_type, under, attributes)
+        data = self.createx(object_type, under, attributes, **kwattrs)
         return data['handle']
 
-    def createx(self, object_type, under=None, attributes=None):
+    def createx(self, object_type, under=None, attributes=None, **kwattrs):
         """Create a new automation object.
 
         Arguments:
         object_type -- Type of object to create.
         under       -- Handle of the parent of the new object.
         attributes  -- Dictionary of attributes (name-value pairs).
+        kwattrs     -- Optional keyword attributes (name=value pairs).
 
         Return:
         Dictionary containing handle of newly created object.
@@ -368,6 +370,8 @@ class StcHttp(object):
             params['under'] = under
         if attributes:
             params.update(attributes)
+        if kwattrs:
+            params.update(kwattrs)
 
         status, data = self._rest.post_request('objects', None, params)
         return data
@@ -393,7 +397,7 @@ class StcHttp(object):
         Arguments:
         command -- Command to execute.
         params  -- Optional.  Dictionary of parameters (name-value pairs).
-        kwargs  -- OPtional keyword arguments (name-value pairs).
+        kwargs  -- Optional keyword arguments (name=value pairs).
 
         Return:
         Data from command.
@@ -408,15 +412,21 @@ class StcHttp(object):
         status, data = self._rest.post_request('perform', None, params)
         return data
 
-    def config(self, handle, attributes=None):
+    def config(self, handle, attributes=None, **kwattrs):
         """Sets or modifies one or more object attributes or relations.
 
         Arguments:
         handle     -- Handle of object to modify.
         attributes -- Dictionary of attributes (name-value pairs).
+        kwattrs    -- Optional keyword attributes (name=value pairs).
 
         """
         self._check_session()
+        if kwattrs:
+            if attributes:
+                attributes.update(kwattrs)
+            else:
+                attributes = kwattrs
         self._rest.put_request('objects', str(handle), attributes)
 
     def chassis(self):

--- a/stcrestclient/tccsh.py
+++ b/stcrestclient/tccsh.py
@@ -449,11 +449,16 @@ class TestCenterCommandShell(cmd.Cmd):
     def do_stc_create(self, args):
         """Create a new automation object.
 
+        Attributes are specified as name=value.  If an attribute is assigned a
+        list of values, then the list of values must be quoted with each value
+        separated by a space: name="value1 value2 value3"
+
         Synopsis:
-            stc_create object_type [under] [attribute, ..]
+            stc_create object_type [under] [attribute=value, ..]
 
         Example:
             stc_create port project1
+            stc_create port project1 location=//10.1.2.3/1/1
 
         """
         if self._not_joined():
@@ -474,11 +479,16 @@ class TestCenterCommandShell(cmd.Cmd):
     def do_stc_perform(self, args):
         """Perform a command.
 
+        Parameters are specified as name=value.  If a parameter is assigned a
+        list of values, then the list of values must be quoted with each value
+        separated by a space: name="value1 value2 value3"
+
         Synopsis:
             stc_perform command [param=value, ...]
 
         Example:
             stc_perform SaveAsXml config=project1 filename=mytest.xml
+            stc_perform AttachPorts portList="port1 port2 port3"
 
         """
         if self._not_joined():
@@ -496,6 +506,10 @@ class TestCenterCommandShell(cmd.Cmd):
 
     def do_stc_config(self, args):
         """Sets or modifies one or more object attributes or relations.
+
+        Attributes are specified as name=value.  If an attribute is assigned a
+        list of values, then the list of values must be quoted with each value
+        separated by a space: name="value1 value2 value3"
 
         Synopsis:
             stc_config handle [name=value, ...]
@@ -814,6 +828,8 @@ class TestCenterCommandShell(cmd.Cmd):
         for arg in args:
             if '=' in arg:
                 k, v = arg.split('=', 1)
+                if ' ' in v:
+                    v = shlex.split(v)
                 params[k] = v
             else:
                 params[arg] = None


### PR DESCRIPTION
In tccsh, parameters for `stc_create`, `stc_config`, and `stc_perform` can have value lists.  These are specified as: `param="value1 value2 value3"`

The `create()`, `createx()`, `config()`, and `perform()` methods of StcHttp can optionally take parameters as kwargs.