### PR TITLE
Specify optional download location.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 def main():
     setup(
         name='stcrestclient',
-        version= '1.6.2',
+        version= '1.7.0',
         author='Andrew Gillis',
         author_email='andrew.gillis@spirent.com',
         url='https://github.com/Spirent/py-stcrestclient',


### PR DESCRIPTION
When downloading a single file, optionally specify a path to download the file as.  If the directory portion of the path does not exist, it is created.

When downloading all files, optionally specify a directory to download the files to.  If the directory does not exist, it is created.

These are optional additional parameters for both `stchttp` and for `tccsh` and do not require a change in any existing code.
