### PR TITLE
Analytics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 def main():
     setup(
         name='stcrestclient',
-        version= '1.7.4',
+        version= '1.7.5',
         author='Andrew Gillis',
         author_email='andrew.gillis@spirent.com',
         url='https://github.com/Spirent/py-stcrestclient',

--- a/stcrestclient/stchttp.py
+++ b/stcrestclient/stchttp.py
@@ -85,7 +85,7 @@ class StcHttp(object):
         self._rest.set_timeout(timeout)
 
     def new_session(self, user_name=None, session_name=None,
-                    kill_existing=False):
+                    kill_existing=False, analytics=None):
         """Create a new test session.
 
         The test session is identified by the specified user_name and optional
@@ -98,6 +98,9 @@ class StcHttp(object):
         kill_existing -- If there is an existing session, with the same session
                          name and user name, then terminate it before creating
                          a new session
+        analytics     -- Optional boolean value to disable or enable analytics
+                         for new session.  None will use setting configured on
+                         server.
 
         Return:
         True is session started, False if session was already started.
@@ -110,6 +113,8 @@ class StcHttp(object):
         if not user_name or not user_name.strip():
             user_name = ''
         params = {'userid': user_name, 'sessionname': session_name}
+        if analytics not in (None, ''):
+            params['analytics'] = str(analytics).lower()
         try:
             status, data = self._rest.post_request('sessions', None, params)
         except resthttp.RestHttpError as e:

--- a/stcrestclient/tccsh.py
+++ b/stcrestclient/tccsh.py
@@ -132,14 +132,21 @@ class TestCenterCommandShell(cmd.Cmd):
                 self.do_delete(session)
 
     def do_new(self, s):
-        """Create a new session: new user_name session_name"""
+        """Create a new session: new user_name session_name [analytics=false]"""
         if self._stc.session_id():
             # End the current session, without deleting TC session.
             self._stc.end_session(False)
         user_name = ''
         session_name = None
+        analytics = None
         params = s.split()
         if params:
+            for p in params:
+                if p.startswith('analytics='):
+                    a = p.split('=', 1)[-1]
+                    if a:
+                        analytics = a.strip()
+                    break
             user_name = params.pop(0)
             if params:
                 session_name = params.pop(0)
@@ -151,12 +158,16 @@ class TestCenterCommandShell(cmd.Cmd):
                 pass
 
         try:
-            sid = self._stc.new_session(user_name, session_name)
+            sid = self._stc.new_session(user_name, session_name,
+                                        analytics=analytics)
         except Exception as e:
             print(e)
             return
         self._update_sessions()
-        print('Created and joined session:', sid)
+        a_msg = ''
+        if analytics:
+            a_msg = ' (analytics=%s)' % (analytics,)
+        print('Created and joined session%s: %s' % (a_msg, sid))
 
     def do_files(self, s):
         """List the files available in the current session."""

--- a/stcrestclient/tccsh.py
+++ b/stcrestclient/tccsh.py
@@ -164,14 +164,15 @@ class TestCenterCommandShell(cmd.Cmd):
         for i, p in enumerate(params):
             if not user_name and p.startswith('user='):
                 rm.insert(0, i)
-                u = p.split('=', 1)[-1]
+                u = p.split('=', 1)[-1].strip()
                 if u:
-                    user_name = u.strip()
+                    user_name = u
             elif not analytics and p.startswith('analytics='):
                 rm.insert(0, i)
-                a = p.split('=', 1)[-1]
+                a = p.split('=', 1)[-1].strip()
                 if a:
-                    analytics = a.strip()
+                    true_vals = ('1', 'true', 'on', 'yes', 'y', 't')
+                    analytics = a.lower() in true_vals
 
         # Remove kw parameters from params list.
         for idx in rm:
@@ -193,7 +194,7 @@ class TestCenterCommandShell(cmd.Cmd):
             msg += ' "%s"' % (session_name,)
         if user_name:
             msg += ' for user "%s"' % (user_name,)
-        if analytics:
+        if analytics is not None:
             msg += ' (analytics=%s)' % (analytics,)
         print(msg, '...')
 


### PR DESCRIPTION
 When creating a new session with `new`, specify `user` and `analytics` as optional keyword parameters.  The only positional parameter is the session name.  This is more convenient as the user typically only need to specify the session name.