### PR TITLE
Add kill command, and some minor fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 def main():
     setup(
         name='stcrestclient',
-        version= '1.7.7',
+        version= '1.8.0',
         author='Andrew Gillis',
         author_email='andrew.gillis@spirent.com',
         url='https://github.com/Spirent/py-stcrestclient',

--- a/stcrestclient/tccsh.py
+++ b/stcrestclient/tccsh.py
@@ -323,15 +323,41 @@ class TestCenterCommandShell(cmd.Cmd):
         if yn:
             print('...waiting for session to end...')
 
+        ended = False
         try:
             self._stc.end_session(yn)
         except Exception as e:
             print(e)
             return
         if yn:
+            self._update_sessions()
             print('Terminated test session', current)
         else:
             print('Detached from test session', current)
+
+    def do_kill(self, session):
+        """Terminate the specified test session"""
+        if not session:
+            print('specify a session to join')
+            return
+
+        if session.endswith(' -') and session.count('-') == 1:
+            session += ' '
+        if self._not_session(session):
+            return
+
+        print('...waiting for session to end...')
+        try:
+            self._stc.end_session(True, session)
+        except Exception as e:
+            print(e)
+            return
+
+        self._update_sessions()
+        print('Terminated test session', session)
+
+    def complete_kill(self, text, line, begidx, endidx):
+        return self._complete_session(text)
 
     def do_server(self, server):
         """Specify STC server.


### PR DESCRIPTION
New `kill` command in tccsh allows termination of a session without having to first join the session.  

Changes in the STC ReST API, as of version 2.2.8, allow the `kill` command to work against a test session that is not responding.

The kill functionality is also available in the ReST client, as it invokes the same DELETE functionality , only without requiring that the client joined a session: `self._stc.end_session(True, session_id)`