### PR TITLE
support aion labserver for authentication

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 VIAVI Solutions, Inc.
+Copyright (c) 2017-2026 VIAVI Solutions, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Spirent Communications, Inc.
+Copyright (c) 2026 VIAVI Solutions, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ All code works with Python2.7 and Python3.x.
 
 ## Topics
 
-- [Quick Start](https://github.com/Spirent/py-stcrestclient#quick-start)
-- [Installation](https://github.com/Spirent/py-stcrestclient#installation)
-- [stchttp Module](https://github.com/Spirent/py-stcrestclient#using-the-stchttp-module)
-- [Using tccsh Command Shell](https://github.com/Spirent/py-stcrestclient#using-the-rest-api-command-line-shell-tccsh)
-- [Automation Client ReST Adapter](https://github.com/Spirent/py-stcrestclient#automation-client-rest-api-adapter)
-- [TestCenter Server Information](https://github.com/Spirent/py-stcrestclient#testcenter-server-information)
-- [Ending Sessions](https://github.com/Spirent/py-stcrestclient#ending-sessions-with-stcrestclient)
-- [Automation to ReST API Quick Reference](https://github.com/Spirent/py-stcrestclient#automation-api-to-rest-api-quick-reference)
+- [Quick Start](https://github.com/Spirent-STC/py-stcrestclient#quick-start)
+- [Installation](https://github.com/Spirent-STC/py-stcrestclient#installation)
+- [stchttp Module](https://github.com/Spirent-STC/py-stcrestclient#using-the-stchttp-module)
+- [Aion Platform Usage](https://github.com/Spirent-STC/py-stcrestclient#using-aionstchttp-with-the-aion-platform)
+- [Using tccsh Command Shell](https://github.com/Spirent-STC/py-stcrestclient#using-the-rest-api-command-line-shell-tccsh)
+- [Automation Client ReST Adapter](https://github.com/Spirent-STC/py-stcrestclient#automation-client-rest-api-adapter)
+- [TestCenter Server Information](https://github.com/Spirent-STC/py-stcrestclient#testcenter-server-information)
+- [Ending Sessions](https://github.com/Spirent-STC/py-stcrestclient#ending-sessions-with-stcrestclient)
+- [Automation to ReST API Quick Reference](https://github.com/Spirent-STC/py-stcrestclient#automation-api-to-rest-api-quick-reference)
 
 ## Quick Start
 - Get Python pip if not already installed (Download https://bootstrap.pypa.io/get-pip.py):
@@ -28,7 +29,7 @@ All code works with Python2.7 and Python3.x.
 
    `pip install -U stcrestclient`
 
-- Interact with TestCenter server using the [command-line shell](https://github.com/Spirent/py-stcrestclient#using-the-rest-api-command-line-shell-tccsh):
+- Interact with TestCenter server using the [command-line shell](https://github.com/Spirent-STC/py-stcrestclient#using-the-rest-api-command-line-shell-tccsh):
 
    `tccsh`
 
@@ -46,7 +47,7 @@ All code works with Python2.7 and Python3.x.
    >>> stc.system_info()
    ```
 
-- Install [client adapter](https://github.com/Spirent/py-stcrestclient#automation-client-rest-api-adapter) for Python automation scripts to use ReST API, without any code change:
+- Install [client adapter](https://github.com/Spirent-STC/py-stcrestclient#automation-client-rest-api-adapter) for Python automation scripts to use ReST API, without any code change:
 
    ```
    python -m stcrestclient.adapt
@@ -71,7 +72,7 @@ To install or upgrade to the latest, use pip to install from pypi:
 
 Or, install from the repository archive URL:
 
-    pip install -U https://github.com/Spirent/py-stcrestclient/archive/master.zip
+    pip install -U https://github.com/Spirent-STC/py-stcrestclient/archive/master.zip
 
 ### Show information about stcrestclient:
 
@@ -81,14 +82,14 @@ If you want to check if the stcrestclient package is installed and see informati
 
 ### Install From Source
 
-The stcrestclient package is installed from source using distutils in the usual way.  Download the [source distribution](https://github.com/Spirent/py-stcrestclient/archive/master.zip) first.  Unzip the zip archive and run the setup.py script to install the package site-wide.  Here are to commands to do that:
+The stcrestclient package is installed from source using distutils in the usual way.  Download the [source distribution](https://github.com/Spirent-STC/py-stcrestclient/archive/master.zip) first.  Unzip the zip archive and run the setup.py script to install the package site-wide.  Here are to commands to do that:
 
-    wget https://github.com/Spirent/py-stcrestclient/archive/master.zip py-stcrestclient.zip
+    wget https://github.com/Spirent-STC/py-stcrestclient/archive/master.zip py-stcrestclient.zip
     unzip py-stcrestclient.zip
     cd py-stcrestclient-*
     sudo python setup.py install
     
-You can also clone the [repository](https://github.com/Spirent/py-stcrestclient) from GitHub.  Instructions for this not included here.
+You can also clone the [repository](https://github.com/Spirent-STC/py-stcrestclient) from GitHub.  Instructions for this not included here.
 
 ## Using the stchttp module
 
@@ -158,7 +159,97 @@ stc.perform('LoadFromXml', {'filename': 'config.xml'})
 stc.end_session(end_tcsession=True)
 ```
 
-For example usage, look in the [examples](https://github.com/Spirent/py-stcrestclient/tree/master/examples) directory for Python code examples.  The examples, like the client lib, will run with either Python2.7 or Python3.x.  The print out command line help for a specific function above, use `pydoc`. For example: `pydoc stcrestclient.stchttp.StcHttp.new_session`
+For example usage, look in the [examples](https://github.com/Spirent-STC/py-stcrestclient/tree/master/examples) directory for Python code examples.  The examples, like the client lib, will run with either Python2.7 or Python3.x.  The print out command line help for a specific function above, use `pydoc`. For example: `pydoc stcrestclient.stchttp.StcHttp.new_session`
+
+## Using AionStcHttp with the AION Platform
+
+`AionStcHttp` is a drop-in replacement for `StcHttp` that handles AION authentication and product-instance discovery automatically.  It authenticates with the AION platform, discovers the target STC LabServer endpoint from the AION inventory, and injects a Bearer token into every HTTP request.  Tokens are refreshed proactively (at 80% of their lifetime) and reactively (on 401 responses), so long-running sessions remain authenticated without any extra code.
+
+### Parameters
+
+| Parameter | Environment Variable | Description |
+|---|---|---|
+| `aion_url` | `AION_URL` | Base URL of the AION platform, e.g. `https://aion.example.com`. |
+| `username` | `AION_USERNAME` | AION user email / username. |
+| `password` | `AION_PASSWORD` | AION user password. |
+| `node_name` | — | AION node name hosting the target product instance, e.g. `10.109.120.117`. Use together with `ui_port` to uniquely identify an instance when multiple nodes or instances are present. |
+| `ui_port` | — | UI port of the target product instance. Use together with `node_name` to uniquely identify an instance when multiple instances are running on the same node. The UI port is the port number visible in AION's Product Manager web page (e.g. `64006`). Omit when only one instance is present. |
+| `product_ca_cert` | — | Path to CA certificate bundle used to verify the stcapi HTTPS connection, e.g. `/path/to/product_ca_cert.pem`. Required when the stcapi endpoint uses HTTPS. |
+| `aion_verify` | — | TLS verification for AION platform calls. Set to `False` to disable verification, or provide a path to a CA bundle. Defaults to `True`. |
+| `debug_print` | — | Enable debug output. Defaults to `False`. |
+| `timeout` | — | HTTP request timeout in seconds. Defaults to `None` (no timeout). |
+
+`aion_url`, `username`, and `password` can be supplied as arguments or via their corresponding environment variables.  The argument takes precedence when both are set.  A `RuntimeError` is raised at construction time if any of the three is missing from both sources.
+
+### Basic Usage
+
+```python
+from stcrestclient.aionstchttp import AionStcHttp
+
+stc = AionStcHttp(
+    aion_url='https://aion.example.com',
+    username='user@example.com',
+    password='secret',
+    product_ca_cert='/path/to/product_ca_cert.pem',
+)
+stc.new_session(user_name='myuser', session_name='mysession')
+stc.create('port', under='project1', name='myport')
+stc.end_session()
+```
+
+### Using Environment Variables
+
+Credentials can be supplied entirely via environment variables, keeping them out of source code:
+
+```bash
+export AION_URL=https://aion.example.com
+export AION_USERNAME=user@example.com
+export AION_PASSWORD=secret
+```
+
+```python
+from stcrestclient.aionstchttp import AionStcHttp
+
+# No credentials in code
+stc = AionStcHttp(product_ca_cert='/path/to/product_ca_cert.pem')
+stc.new_session(user_name='myuser', session_name='mysession')
+```
+
+### Obtaining the AION Cluster Certificate for aion_verify
+
+If the AION platform uses a self-signed certificate, set `aion_verify` to the path of the certificate file.  Use the following command to retrieve and save the certificate from the AION cluster:
+
+```bash
+echo | openssl s_client -connect 10.109.120.117:443 2>/dev/null | openssl x509 > aion_cluster.pem
+```
+
+Replace `10.109.120.117` with the address of your AION cluster.  Then pass the saved file to `aion_verify`:
+
+```python
+stc = AionStcHttp(
+    aion_url='https://10.109.120.117',
+    username='user@example.com',
+    password='secret',
+    aion_verify='aion_cluster.pem',
+)
+```
+
+### Selecting a Specific Instance
+
+When multiple STC LabServer instances are running across AION nodes, use `node_name` and `ui_port` together to uniquely identify the target instance.  The node name and UI port are visible in AION's Product Manager web page.  The matching stcapi port is discovered automatically.
+
+```python
+stc = AionStcHttp(
+    aion_url='https://aion.example.com',
+    username='user@example.com',
+    password='secret',
+    node_name='10.109.120.117',
+    ui_port=64006,
+    product_ca_cert='/path/to/product_ca_cert.pem',
+)
+```
+
+
 
 ## Using the ReST API Command-line Shell: tccsh
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ sb_handle = stc.create('streamBlock', port_handle)
 # Apply config
 stc.apply()
 
-# Run STAK command to archive log files
-stc.perform('spirent.core.ArchiveDiagnosticLogsCommand')
-
 # Wait for sequencer to finish
 stc.wait_until_complete(timeout=30)
 
@@ -174,8 +171,8 @@ For example usage, look in the [examples](https://github.com/Spirent-STC/py-stcr
 | `password` | `AION_PASSWORD` | AION user password. |
 | `node_name` | — | AION node name hosting the target product instance, e.g. `10.109.120.117`. Use together with `ui_port` to uniquely identify an instance when multiple nodes or instances are present. |
 | `ui_port` | — | UI port of the target product instance. Use together with `node_name` to uniquely identify an instance when multiple instances are running on the same node. The UI port is the port number visible in AION's Product Manager web page (e.g. `64006`). Omit when only one instance is present. |
-| `product_ca_cert` | — | Path to CA certificate bundle used to verify the stcapi HTTPS connection, e.g. `/path/to/product_ca_cert.pem`. Required when the stcapi endpoint uses HTTPS. |
-| `aion_verify` | — | TLS verification for AION platform calls. Set to `False` to disable verification, or provide a path to a CA bundle. Defaults to `True`. |
+| `product_ca_cert` | — | Path to CA certificate file used to verify the stcapi HTTPS connection, e.g. `/path/to/product_ca_cert.pem`. Required when the stcapi endpoint uses HTTPS. |
+| `aion_ca_cert` | — | Path to CA certificate file used to verify the AION platform HTTPS connection, e.g. `'/path/to/aion_ca_cert.pem'`. Required when the AION platform uses HTTPS. |
 | `debug_print` | — | Enable debug output. Defaults to `False`. |
 | `timeout` | — | HTTP request timeout in seconds. Defaults to `None` (no timeout). |
 
@@ -215,22 +212,22 @@ stc = AionStcHttp(product_ca_cert='/path/to/product_ca_cert.pem')
 stc.new_session(user_name='myuser', session_name='mysession')
 ```
 
-### Obtaining the AION Cluster Certificate for aion_verify
+### Obtaining the AION Cluster Certificate for aion_ca_cert
 
-If the AION platform uses a self-signed certificate, set `aion_verify` to the path of the certificate file.  Use the following command to retrieve and save the certificate from the AION cluster:
+If the AION platform uses a self-signed certificate, set `aion_ca_cert` to the path of the certificate file.  Use the following command to retrieve and save the certificate from the AION cluster:
 
 ```bash
 echo | openssl s_client -connect 10.109.120.117:443 2>/dev/null | openssl x509 > aion_cluster.pem
 ```
 
-Replace `10.109.120.117` with the address of your AION cluster.  Then pass the saved file to `aion_verify`:
+Replace `10.109.120.117` with the address of your AION cluster.  Then pass the saved file to `aion_ca_cert`:
 
 ```python
 stc = AionStcHttp(
     aion_url='https://10.109.120.117',
     username='user@example.com',
     password='secret',
-    aion_verify='aion_cluster.pem',
+    aion_ca_cert='aion_cluster.pem',
 )
 ```
 

--- a/examples/aion_createsession.py
+++ b/examples/aion_createsession.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+import sys
+from stcrestclient.aionstchttp import AionStcHttp
+
+session_name = 'aion-example'
+user_name = 'aionuser'
+
+if len(sys.argv) < 4:
+    print('usage: python', sys.argv[0], '<aion_url> <username> <password>',
+          file=sys.stderr)
+    sys.exit(1)
+
+aion_url, username, password = sys.argv[1], sys.argv[2], sys.argv[3]
+
+try:
+    stc = AionStcHttp(
+        aion_url=aion_url,
+        username=username,
+        password=password,
+    )
+
+    sid = stc.new_session(user_name=user_name, session_name=session_name)
+    print('Created session:', sid)
+
+    info = stc.system_info()
+    print('System info:', info)
+
+    project = stc.create('project')
+    print('Project handle:', project)
+
+    port1 = stc.create('port', project)
+    print('Port 1 handle:', port1)
+
+    port2 = stc.create('port', project)
+    print('Port 2 handle:', port2)
+
+    stc.end_session()
+    print('Session ended.')
+
+except Exception as e:
+    print(e, file=sys.stderr)
+    sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 def main():
     setup(
         name='stcrestclient',
-        version= '1.9.5',
+        version= '1.9.6',
         author='VIAVI Solutions',
         author_email='hse.support@viavisolutions.com',
         url='https://github.com/Spirent-STC/py-stcrestclient',

--- a/stcrestclient/aionauth.py
+++ b/stcrestclient/aionauth.py
@@ -1,0 +1,252 @@
+"""
+AION platform authentication and endpoint discovery.
+
+Handles the interactions needed before talking to AION labserver:
+  1. GET  /api/iam/organizations/default     -- discover org_id
+  2. POST /api/iam/oauth2/token              -- login (password grant)
+  3. POST /api/iam/oauth2/token              -- refresh (refresh_token grant)
+  4. GET  /api/inv/product-instances         -- discover stcapi host/port
+
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import time
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+import requests
+
+# Fraction of token lifetime elapsed before a proactive refresh is triggered.
+_REFRESH_THRESHOLD = 0.8
+
+
+class AionAuthError(Exception):
+    """Raised when an AION IAM or inventory operation fails."""
+
+    def __init__(self, message, http_status=None):
+        self.http_status = http_status
+        super(AionAuthError, self).__init__(message)
+
+
+class AionAuth(object):
+    """
+    Manages AION authentication and stcapi endpoint discovery.
+
+    Typical usage::
+
+        auth = AionAuth(aion_url='https://aion.example.com')
+        org_id = auth.get_default_org()
+        auth.login('user@example.com', 'password', org_id)
+        proto, host, port = auth.get_stcapi_endpoint()
+        # use auth.access_token as Bearer token for stcapi calls
+        # call auth.refresh() to renew before expiry
+
+    """
+
+    def __init__(self, aion_url, ssl_verify=True, debug_print=False):
+        """
+        Arguments:
+        aion_url    -- Base URL of the AION platform, e.g. 'https://aion.example.com'
+        ssl_verify  -- Set to False to disable TLS certificate verification,
+                       or a path string to a CA bundle file.
+        debug_print -- Enable debug print statements.
+        """
+        self._aion_url = aion_url.rstrip('/')
+        self._ssl_verify = ssl_verify
+        self._dbg_print = bool(debug_print)
+        self._access_token = None
+        self._refresh_token = None
+        self._expires_in = 86400
+        self._login_time = 0.0
+
+    def get_default_org(self):
+        """Return the default organization ID from the AION platform.
+
+          GET /api/iam/organizations/default
+
+        Return:
+        Organization ID string.
+
+        """
+        url = self._aion_url + '/api/iam/organizations/default'
+        if self._dbg_print:
+            print('===> GET %s' % url)
+        resp = requests.get(url, verify=self._ssl_verify)
+        if self._dbg_print:
+            print('===> response status: %d %s' % (resp.status_code, resp.reason))
+        if resp.status_code != 200:
+            raise AionAuthError(
+                'failed to get default org: %d %s' % (resp.status_code, resp.text),
+                resp.status_code)
+        data = resp.json()
+        if self._dbg_print:
+            print('===> default org id: %s' % data['id'])
+        return data['id']
+
+    def login(self, username, password, org_id=None):
+        """Login to the AION platform and store the resulting tokens.
+
+          POST /api/iam/oauth2/token  {grant_type=password}
+
+        If org_id is not supplied, get_default_org() is called automatically.
+
+        Arguments:
+        username -- AION user email / username.
+        password -- AION user password.
+        org_id   -- Organization ID to use as OAuth2 scope.  None to
+                    auto-discover via get_default_org().
+
+        """
+        if org_id is None:
+            org_id = self.get_default_org()
+        url = self._aion_url + '/api/iam/oauth2/token'
+        if self._dbg_print:
+            print('===> POST %s' % url)
+            print('  --- Params ---')
+            print('    grant_type: password, username: %s, password: ******, scope: %s'
+                  % (username, org_id))
+        data = {
+            'grant_type': 'password',
+            'username': username,
+            'password': password,
+            'scope': org_id,
+        }
+        resp = requests.post(url, data=data, verify=self._ssl_verify)
+        if self._dbg_print:
+            print('===> response status: %d %s' % (resp.status_code, resp.reason))
+        if resp.status_code != 200:
+            raise AionAuthError(
+                'login failed: %d %s' % (resp.status_code, resp.text),
+                resp.status_code)
+        self._store_tokens(resp.json())
+        if self._dbg_print:
+            print('===> login succeeded, token expires_in: %ds' % self._expires_in)
+
+    def refresh(self):
+        """Refresh the access token using the stored refresh token.
+
+          POST /api/iam/oauth2/token  {grant_type=refresh_token}
+
+        Both access_token and refresh_token are replaced with the new values
+        returned by IAM.
+
+        """
+        if not self._refresh_token:
+            raise AionAuthError('no refresh token available; call login() first')
+        url = self._aion_url + '/api/iam/oauth2/token'
+        if self._dbg_print:
+            print('===> POST %s' % url)
+            print('  --- Params ---')
+            print('    grant_type: refresh_token')
+        data = {
+            'grant_type': 'refresh_token',
+            'refresh_token': self._refresh_token,
+        }
+        resp = requests.post(url, data=data, verify=self._ssl_verify)
+        if self._dbg_print:
+            print('===> response status: %d %s' % (resp.status_code, resp.reason))
+        if resp.status_code != 200:
+            raise AionAuthError(
+                'token refresh failed: %d %s' % (resp.status_code, resp.text),
+                resp.status_code)
+        self._store_tokens(resp.json())
+        if self._dbg_print:
+            print('===> token refresh succeeded, new token expires_in: %ds' % self._expires_in)
+
+    def get_stcapi_endpoint(self, node_name=None, ui_port=None):
+        """Discover the stcapi host and port from AION inventory.
+
+          GET /api/inv/product-instances
+
+        Arguments:
+        node_name -- Optional AION node name.  When supplied, only instances
+                     on the named node are considered.
+        ui_port   -- Optional integer UI port number.  When supplied, the
+                     instance whose UI port (has_ui=true) matches this value
+                     is selected.  When omitted, the first instance with a
+                     stcapi port is used.
+
+        Return:
+        Tuple of (proto, host, port) for the stcapi product instance,
+        where proto is 'http' or 'https' as reported by the inventory.
+
+        """
+        if not self._access_token:
+            raise AionAuthError('not logged in; call login() first')
+        url = self._aion_url + '/api/inv/product-instances'
+        if self._dbg_print:
+            print('===> GET %s' % url)
+        headers = {'Authorization': 'Bearer ' + self._access_token}
+        resp = requests.get(url, headers=headers, verify=self._ssl_verify)
+        if self._dbg_print:
+            print('===> response status: %d %s' % (resp.status_code, resp.reason))
+        if resp.status_code != 200:
+            raise AionAuthError(
+                'failed to get product instances: %d %s' % (resp.status_code, resp.text),
+                resp.status_code)
+        instances = resp.json()
+        for inst in instances:
+            if node_name is not None and inst.get('node', {}).get('name') != node_name:
+                continue
+            ui_match = (ui_port is None)
+            stcapi_url = None
+            for p in inst.get('ports', []):
+                http = p.get('http', {})
+                name = p.get('name', '').lower()
+                if not ui_match and http.get('has_ui') and urlparse(http.get('url', '')).port == ui_port:
+                    ui_match = True
+                if name == 'stcapi':
+                    stcapi_url = http.get('url', '')
+            if not ui_match or not stcapi_url:
+                continue
+            parsed = urlparse(stcapi_url)
+            proto = parsed.scheme
+            host = parsed.hostname
+            port = parsed.port
+            if not proto or not host or not port:
+                raise AionAuthError(
+                    'stcapi port entry has invalid url: %s' % stcapi_url)
+            if self._dbg_print:
+                print('===> stcapi endpoint: %s://%s:%d' % (proto, host, port))
+            return proto, host, port
+        if node_name is not None and ui_port is not None:
+            raise AionAuthError(
+                'no stcapi port entry found for node_name %s, ui_port %d' % (node_name, ui_port))
+        if node_name is not None:
+            raise AionAuthError(
+                'no stcapi port entry found for node_name %s' % node_name)
+        if ui_port is not None:
+            raise AionAuthError(
+                'no stcapi port entry found for ui_port %d' % ui_port)
+        raise AionAuthError('no stcapi port entry found in AION product instances')
+
+    def needs_refresh(self):
+        """Return True if the access token should be refreshed proactively.
+
+        Triggers at 80% of the token lifetime to ensure the token does not
+        expire during an active session.
+
+        """
+        if not self._access_token:
+            return False
+        elapsed = time.time() - self._login_time
+        needed = elapsed >= self._expires_in * _REFRESH_THRESHOLD
+        if needed and self._dbg_print:
+            print('===> proactive token refresh needed (elapsed: %.0fs, threshold: %.0fs)'
+                  % (elapsed, self._expires_in * _REFRESH_THRESHOLD))
+        return needed
+
+    @property
+    def access_token(self):
+        """Current access token string, or None if not logged in."""
+        return self._access_token
+
+    def _store_tokens(self, data):
+        self._access_token = data['access_token']
+        self._refresh_token = data['refresh_token']
+        self._expires_in = float(data.get('expires_in', 86400))
+        self._login_time = time.time()

--- a/stcrestclient/aionauth.py
+++ b/stcrestclient/aionauth.py
@@ -24,12 +24,12 @@ import requests
 _REFRESH_THRESHOLD = 0.8
 
 
-class AionAuthError(Exception):
+class AionError(Exception):
     """Raised when an AION IAM or inventory operation fails."""
 
     def __init__(self, message, http_status=None):
         self.http_status = http_status
-        super(AionAuthError, self).__init__(message)
+        super(AionError, self).__init__(message)
 
 
 class AionAuth(object):
@@ -47,21 +47,21 @@ class AionAuth(object):
 
     """
 
-    def __init__(self, aion_url, ssl_verify=True, debug_print=False):
+    def __init__(self, aion_url, ca_cert='', debug_print=False):
         """
         Arguments:
         aion_url    -- Base URL of the AION platform, e.g. 'https://aion.example.com'
-        ssl_verify  -- Set to False to disable TLS certificate verification,
-                       or a path string to a CA bundle file.
+        ca_cert     -- Path to CA certificate file used to verify the AION platform
+                       HTTPS connection, e.g. '/path/to/aion_ca.pem'. 
         debug_print -- Enable debug print statements.
         """
         self._aion_url = aion_url.rstrip('/')
-        self._ssl_verify = ssl_verify
+        self._ssl_verify = ca_cert if ca_cert else True
         self._dbg_print = bool(debug_print)
         self._access_token = None
         self._refresh_token = None
         self._expires_in = 86400
-        self._login_time = 0.0
+        self._last_refresh_time = 0.0
 
     def get_default_org(self):
         """Return the default organization ID from the AION platform.
@@ -79,7 +79,7 @@ class AionAuth(object):
         if self._dbg_print:
             print('===> response status: %d %s' % (resp.status_code, resp.reason))
         if resp.status_code != 200:
-            raise AionAuthError(
+            raise AionError(
                 'failed to get default org: %d %s' % (resp.status_code, resp.text),
                 resp.status_code)
         data = resp.json()
@@ -119,7 +119,7 @@ class AionAuth(object):
         if self._dbg_print:
             print('===> response status: %d %s' % (resp.status_code, resp.reason))
         if resp.status_code != 200:
-            raise AionAuthError(
+            raise AionError(
                 'login failed: %d %s' % (resp.status_code, resp.text),
                 resp.status_code)
         self._store_tokens(resp.json())
@@ -136,7 +136,7 @@ class AionAuth(object):
 
         """
         if not self._refresh_token:
-            raise AionAuthError('no refresh token available; call login() first')
+            raise AionError('no refresh token available; call login() first')
         url = self._aion_url + '/api/iam/oauth2/token'
         if self._dbg_print:
             print('===> POST %s' % url)
@@ -150,7 +150,7 @@ class AionAuth(object):
         if self._dbg_print:
             print('===> response status: %d %s' % (resp.status_code, resp.reason))
         if resp.status_code != 200:
-            raise AionAuthError(
+            raise AionError(
                 'token refresh failed: %d %s' % (resp.status_code, resp.text),
                 resp.status_code)
         self._store_tokens(resp.json())
@@ -176,7 +176,7 @@ class AionAuth(object):
 
         """
         if not self._access_token:
-            raise AionAuthError('not logged in; call login() first')
+            raise AionError('not logged in; call login() first')
         url = self._aion_url + '/api/inv/product-instances'
         if self._dbg_print:
             print('===> GET %s' % url)
@@ -185,7 +185,7 @@ class AionAuth(object):
         if self._dbg_print:
             print('===> response status: %d %s' % (resp.status_code, resp.reason))
         if resp.status_code != 200:
-            raise AionAuthError(
+            raise AionError(
                 'failed to get product instances: %d %s' % (resp.status_code, resp.text),
                 resp.status_code)
         instances = resp.json()
@@ -208,21 +208,21 @@ class AionAuth(object):
             host = parsed.hostname
             port = parsed.port
             if not proto or not host or not port:
-                raise AionAuthError(
+                raise AionError(
                     'stcapi port entry has invalid url: %s' % stcapi_url)
             if self._dbg_print:
                 print('===> stcapi endpoint: %s://%s:%d' % (proto, host, port))
             return proto, host, port
         if node_name is not None and ui_port is not None:
-            raise AionAuthError(
+            raise AionError(
                 'no stcapi port entry found for node_name %s, ui_port %d' % (node_name, ui_port))
         if node_name is not None:
-            raise AionAuthError(
+            raise AionError(
                 'no stcapi port entry found for node_name %s' % node_name)
         if ui_port is not None:
-            raise AionAuthError(
+            raise AionError(
                 'no stcapi port entry found for ui_port %d' % ui_port)
-        raise AionAuthError('no stcapi port entry found in AION product instances')
+        raise AionError('no stcapi port entry found in AION product instances')
 
     def needs_refresh(self):
         """Return True if the access token should be refreshed proactively.
@@ -233,7 +233,7 @@ class AionAuth(object):
         """
         if not self._access_token:
             return False
-        elapsed = time.time() - self._login_time
+        elapsed = time.time() - self._last_refresh_time
         needed = elapsed >= self._expires_in * _REFRESH_THRESHOLD
         if needed and self._dbg_print:
             print('===> proactive token refresh needed (elapsed: %.0fs, threshold: %.0fs)'
@@ -249,4 +249,4 @@ class AionAuth(object):
         self._access_token = data['access_token']
         self._refresh_token = data['refresh_token']
         self._expires_in = float(data.get('expires_in', 86400))
-        self._login_time = time.time()
+        self._last_refresh_time = time.time()

--- a/stcrestclient/aionstchttp.py
+++ b/stcrestclient/aionstchttp.py
@@ -1,0 +1,201 @@
+"""
+AionStcHttp -- StcHttp subclass with transparent AION authentication
+and automatic token refresh.
+
+Usage::
+
+    from stcrestclient.aionstchttp import AionStcHttp
+
+    stc = AionStcHttp(
+        aion_url='https://aion.example.com',   # or set AION_URL
+        username='user@example.com',            # or set AION_USERNAME
+        password='secret',                      # or set AION_PASSWORD
+        product_ca_cert='/path/to/ca_crt.pem',
+    )
+    stc.new_session(user_name='myuser', session_name='mysession')
+    stc.create("port", under="project1", name="myport")
+    stc.end_session()
+
+The class transparently:
+  - Discovers the default org and authenticates with AION IAM before connecting.
+  - Discovers the stcapi host/port from AION inventory.
+  - Injects the Bearer token into every HTTP request.
+  - Proactively refreshes the token at 80% of its lifetime.
+  - Reactively refreshes and retries on 401/4002 (AUTH_TOKEN_INVALID).
+
+Original StcHttp users are unaffected -- they do not import this module.
+
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+
+try:
+    from . import resthttp
+    from .stchttp import StcHttp
+    from .aionauth import AionAuth
+except (ImportError, ValueError):
+    import resthttp
+    from stchttp import StcHttp
+    from aionauth import AionAuth
+
+
+class AionStcHttp(StcHttp):
+    """StcHttp subclass with transparent AION IAM authentication.
+
+    Handles login, product-instance discovery, token injection, and token
+    refresh automatically.  The API is identical to StcHttp -- customers
+    call the same methods with no changes.
+
+    Arguments:
+    aion_url        -- AION platform base URL, e.g. 'https://aion.example.com'.
+                       Falls back to AION_URL environment variable if not supplied.
+    username        -- AION user email / username.
+                       Falls back to AION_USERNAME environment variable if not supplied.
+    password        -- AION user password.
+                       Falls back to AION_PASSWORD environment variable if not supplied.
+    node_name       -- AION node name hosting the target product instance,
+                       e.g. '10.109.120.117'.  Use together with ui_port to
+                       uniquely identify an instance when multiple nodes or
+                       instances are present.
+    ui_port         -- UI port number of the target product instance.  When
+                       multiple instances are running on the same node, supply
+                       this together with node_name to uniquely identify the
+                       desired one (e.g. 64006 selects the instance whose UI
+                       port is 64006 and connects to its stcapi port).
+                       Omit when only one instance is present.
+    product_ca_cert -- Path to CA certificate bundle used to verify the stcapi
+                       HTTPS connection, e.g. '/path/to/product_ca_cert.pem'.
+                       Required when the stcapi endpoint uses HTTPS.
+    aion_verify     -- False to skip TLS verification of the AION platform URL,
+                       or path to CA bundle for AION calls.
+    debug_print     -- Enable debug output.
+    timeout         -- HTTP request timeout in seconds.
+
+    Environment variables:
+    AION_URL      -- AION platform base URL (used when aion_url is not supplied).
+    AION_USERNAME -- AION user email / username (used when username is not supplied).
+    AION_PASSWORD -- AION user password (used when password is not supplied).
+
+    """
+
+    def __init__(self, aion_url=None, username=None, password=None,
+                 node_name=None, ui_port=None, product_ca_cert='', aion_verify=True,
+                 debug_print=False, timeout=None):
+        aion_url = aion_url or os.environ.get('AION_URL')
+        username = username or os.environ.get('AION_USERNAME')
+        password = password or os.environ.get('AION_PASSWORD')
+
+        if not aion_url:
+            raise RuntimeError('aion_url is required (or set AION_URL)')
+        if not username:
+            raise RuntimeError('username is required (or set AION_USERNAME)')
+        if not password:
+            raise RuntimeError('password is required (or set AION_PASSWORD)')
+
+        # Discover org and login to AION
+        self._auth = AionAuth(aion_url, ssl_verify=aion_verify,
+                              debug_print=debug_print)
+        self._auth.login(username, password)
+
+        # Discover stcapi proto/host/port from AION inventory
+        proto, host, port = self._auth.get_stcapi_endpoint(node_name=node_name, ui_port=ui_port)
+
+        # Initialise StcHttp -- proto/host/port from inventory, token injected into base headers
+        super(AionStcHttp, self).__init__(
+            server=host,
+            port=port,
+            use_https=(proto == 'https'),
+            ca_cert=product_ca_cert,
+            debug_print=debug_print,
+            timeout=timeout,
+            token=self._auth.access_token,
+        )
+
+        # Replace self._rest with _AionRestHttp so every HTTP call goes
+        # through the refresh wrapper.
+        aion_rest = _AionRestHttp.__new__(_AionRestHttp)
+        aion_rest.__dict__.update(self._rest.__dict__)
+        aion_rest._proactive_cb = self._auth.needs_refresh
+        aion_rest._refresh_cb = self._do_refresh
+        self._rest = aion_rest
+
+    def _do_refresh(self):
+        """Refresh the AION token and return the new access token string."""
+        if self._dbg_print:
+            print('===> refreshing AION token')
+        self._auth.refresh()
+        if self._dbg_print:
+            print('===> AION token refreshed successfully')
+        return self._auth.access_token
+
+
+class _AionRestHttp(resthttp.RestHttp):
+    """RestHttp subclass that wraps every HTTP method with token-refresh logic.
+
+    Two callbacks are installed by AionStcHttp after construction:
+      _proactive_cb  -- () -> bool  : True if a proactive refresh is needed.
+      _refresh_cb    -- () -> str   : Performs the refresh, returns new token.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(_AionRestHttp, self).__init__(*args, **kwargs)
+        self._proactive_cb = None
+        self._refresh_cb = None
+
+    def _wrap(self, fn, *args, **kwargs):
+        """Run fn, refreshing the token proactively and on TokenExpiredError."""
+        if self._proactive_cb and self._proactive_cb():
+            if self._dbg_print:
+                print('===> proactive token refresh triggered before request')
+            new_token = self._refresh_cb()
+            self.add_header('Authorization', 'Bearer ' + new_token)
+            if self._dbg_print:
+                print('===> proactive token refresh complete, retrying with new token')
+        try:
+            return fn(*args, **kwargs)
+        except resthttp.TokenExpiredError:
+            if self._dbg_print:
+                print('===> token expired (401/4002), triggering reactive refresh')
+            if self._refresh_cb:
+                new_token = self._refresh_cb()
+                self.add_header('Authorization', 'Bearer ' + new_token)
+                if self._dbg_print:
+                    print('===> reactive token refresh complete, retrying request')
+                return fn(*args, **kwargs)
+            raise
+
+    def get_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).get_request, *args, **kwargs)
+
+    def post_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).post_request, *args, **kwargs)
+
+    def put_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).put_request, *args, **kwargs)
+
+    def delete_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).delete_request, *args, **kwargs)
+
+    def download_file(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).download_file, *args, **kwargs)
+
+    def upload_file(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).upload_file, *args, **kwargs)
+
+    def upload_file_mp(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).upload_file_mp, *args, **kwargs)
+
+    def upload_files(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).upload_files, *args, **kwargs)
+
+    def bulk_get_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).bulk_get_request, *args, **kwargs)
+
+    def bulk_put_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).bulk_put_request, *args, **kwargs)
+
+    def bulk_post_request(self, *args, **kwargs):
+        return self._wrap(super(_AionRestHttp, self).bulk_post_request, *args, **kwargs)

--- a/stcrestclient/aionstchttp.py
+++ b/stcrestclient/aionstchttp.py
@@ -65,11 +65,12 @@ class AionStcHttp(StcHttp):
                        desired one (e.g. 64006 selects the instance whose UI
                        port is 64006 and connects to its stcapi port).
                        Omit when only one instance is present.
-    product_ca_cert -- Path to CA certificate bundle used to verify the stcapi
+    product_ca_cert -- Path to CA certificate file used to verify the stcapi
                        HTTPS connection, e.g. '/path/to/product_ca_cert.pem'.
                        Required when the stcapi endpoint uses HTTPS.
-    aion_verify     -- False to skip TLS verification of the AION platform URL,
-                       or path to CA bundle for AION calls.
+    aion_ca_cert    -- Path to CA certificate file used to verify the AION
+                       platform HTTPS connection, e.g. '/path/to/aion_ca.pem'.
+                       Required when the AION platform uses HTTPS.
     debug_print     -- Enable debug output.
     timeout         -- HTTP request timeout in seconds.
 
@@ -81,7 +82,7 @@ class AionStcHttp(StcHttp):
     """
 
     def __init__(self, aion_url=None, username=None, password=None,
-                 node_name=None, ui_port=None, product_ca_cert='', aion_verify=True,
+                 node_name=None, ui_port=None, product_ca_cert='', aion_ca_cert='',
                  debug_print=False, timeout=None):
         aion_url = aion_url or os.environ.get('AION_URL')
         username = username or os.environ.get('AION_USERNAME')
@@ -95,7 +96,7 @@ class AionStcHttp(StcHttp):
             raise RuntimeError('password is required (or set AION_PASSWORD)')
 
         # Discover org and login to AION
-        self._auth = AionAuth(aion_url, ssl_verify=aion_verify,
+        self._auth = AionAuth(aion_url, ca_cert=aion_ca_cert,
                               debug_print=debug_print)
         self._auth.login(username, password)
 

--- a/stcrestclient/resthttp.py
+++ b/stcrestclient/resthttp.py
@@ -40,6 +40,19 @@ class RestHttpError(Exception):
         return self.http_status
 
 
+class TokenExpiredError(RestHttpError):
+
+    """
+    Exception raised when stc-web returns 401 with code 4002 (AUTH_TOKEN_INVALID).
+
+    Catching RestHttpError also catches this; catch TokenExpiredError specifically
+    to trigger a token refresh and retry.
+
+    """
+
+    pass
+
+
 class ConnectionError(Exception):
 
     def __init__(self, message, code, detail=None):
@@ -447,6 +460,8 @@ class RestHttp(object):
                 else:
                     detail = 'unknown error: ' + str(data)
 
+            if rsp.status_code == 401 and code == 4002:
+                raise TokenExpiredError(rsp.status_code, rsp.reason, detail, code)
             raise RestHttpError(rsp.status_code, rsp.reason, detail, code)
 
         return rsp.status_code, data

--- a/stcrestclient/stchttp.py
+++ b/stcrestclient/stchttp.py
@@ -95,18 +95,6 @@ class StcHttp(object):
     def session_id(self):
         return self._sid
 
-    def set_token(self, token):
-        """Update the Bearer token sent with every request.
-
-        Used by AionStcHttp after a token refresh, but can also be called
-        directly if the caller manages token lifecycle externally.
-
-        Arguments:
-        token -- New Bearer token string.
-
-        """
-        self._rest.add_header('Authorization', 'Bearer ' + token)
-
     def timeout(self):
         """Return the current timeout value."""
         return self._rest.timeout()

--- a/stcrestclient/stchttp.py
+++ b/stcrestclient/stchttp.py
@@ -35,7 +35,7 @@ class StcHttp(object):
     """
 
     def __init__(self, server=None, port=None, api_version=1, use_https=False, ca_cert="",
-                 debug_print=False, timeout=None):
+                 debug_print=False, timeout=None, token=None):
         """Initialize the REST API wrapper object.
 
         If the port to connect to is not specified by the port argument, or by
@@ -79,6 +79,8 @@ class StcHttp(object):
 
         url = resthttp.RestHttp.url(proto, server, port, 'stcapi')
         rest = resthttp.RestHttp(url, debug_print=debug_print, timeout=timeout)
+        if token:
+            rest.add_header('Authorization', 'Bearer ' + token)
         try:
             rest.get_request('sessions')
         except (socket.error, resthttp.ConnectionError,
@@ -86,13 +88,24 @@ class StcHttp(object):
             raise RuntimeError('Cannot connect to STC server: %s:%s' %
                                (server, port))
 
-        rest.add_header('X-Spirent-API-Version', str(api_version))
         self._rest = rest
         self._sid = None
         self._api_ver = None
 
     def session_id(self):
         return self._sid
+
+    def set_token(self, token):
+        """Update the Bearer token sent with every request.
+
+        Used by AionStcHttp after a token refresh, but can also be called
+        directly if the caller manages token lifecycle externally.
+
+        Arguments:
+        token -- New Bearer token string.
+
+        """
+        self._rest.add_header('Authorization', 'Bearer ' + token)
 
     def timeout(self):
         """Return the current timeout value."""
@@ -601,7 +614,7 @@ class StcHttp(object):
 
         if isinstance(data, (list, tuple, set)):
             return ' '.join((str(i) for i in data))
-        return data['message']
+        return data['message'] if 'message' in data else data
 
     def log(self, level, msg):
         """Write a diagnostic message to a log file or to standard output.

--- a/stcrestclient/stcpythonrest.py
+++ b/stcrestclient/stcpythonrest.py
@@ -320,13 +320,13 @@ class StcPythonRest(object):
             example="stc.delete(stream1)"),
 
         connect=dict(
-            desc=("connect: -Establishes a connection with a Spirent "
+            desc=("connect: -Establishes a connection with a "
                   "TestCenter chassis"),
             usage="stc.connect(hostnameOrIPaddress, ...)",
             example="stc.connect(mychassis1)"
             ),
         disconnect=dict(
-            desc=("disconnect: -Removes a connection with a Spirent "
+            desc=("disconnect: -Removes a connection with a "
                   "TestCenter chassis"),
             usage="stc.disconnect(hostnameOrIPaddress, ...)",
             example="stc.disconnect(mychassis1)"
@@ -342,7 +342,7 @@ class StcPythonRest(object):
             example='stc.release("//#{mychassis1}/1/1", "//#{mychassis1}/1/2")'
             ),
         apply=dict(
-            desc=("apply: -Applies a test configuration to the Spirent "
+            desc=("apply: -Applies a test configuration to the "
                   "TestCenter firmware"),
             usage="stc.apply()",
             example="stc.apply()"

--- a/stcrestclient/tccsh.py
+++ b/stcrestclient/tccsh.py
@@ -1,5 +1,5 @@
 """
-Spirent TestCenter Command Shell
+TestCenter Command Shell
 
 Command shell that provides STC Automation API functionality using an
 interactive command line interface, or command file.  This program accesses a
@@ -40,7 +40,7 @@ if sys.hexversion < 0x03000000:
 
 class TestCenterCommandShell(cmd.Cmd):
 
-    intro = 'Welcome to Spirent TestCenter Command Shell (tccsh)'
+    intro = 'Welcome to TestCenter Command Shell (tccsh)'
     _stc = None
     _sessions = []
     _server = None
@@ -884,7 +884,6 @@ class TestCenterCommandShell(cmd.Cmd):
 
         List examples:
             stc_help list commands wait*
-            stc_help list commands spirent.methodology.*
 
         """
         help_args = None


### PR DESCRIPTION
1. Rebranding: drop "Spirent" or change to VIAVI. 
2. Remove rest.add_header('X-Spirent-API-Version', str(api_version)) in stchttp.py, which does not really need, because stc-web's maxVersion = 1 and that's the only version it supports.
3. Enhance the lib by adding AionStcHttp, which is StcHttp subclass with transparent AION authentication and automatic token refresh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Spirent-STC/py-stcrestclient/37)
<!-- Reviewable:end -->
