### PR TITLE
fix: prefer managed session endpoint over raw stcapi port in AION discovery

### DIFF
--- a/stcrestclient/aionauth.py
+++ b/stcrestclient/aionauth.py
@@ -41,7 +41,7 @@ class AionAuth(object):
         auth = AionAuth(aion_url='https://aion.example.com')
         org_id = auth.get_default_org()
         auth.login('user@example.com', 'password', org_id)
-        proto, host, port = auth.get_stcapi_endpoint()
+        proto, host, port, via_managed = auth.get_stcapi_endpoint()
         # use auth.access_token as Bearer token for stcapi calls
         # call auth.refresh() to renew before expiry
 
@@ -171,8 +171,10 @@ class AionAuth(object):
                      stcapi port is used.
 
         Return:
-        Tuple of (proto, host, port) for the stcapi product instance,
-        where proto is 'http' or 'https' as reported by the inventory.
+        Tuple of (proto, host, port, via_managed) for the stcapi product
+        instance, where proto is 'http' or 'https' as reported by the
+        inventory, and via_managed is True when the endpoint routes through
+        the product's managed session layer rather than the raw stcapi port.
 
         """
         if not self._access_token:
@@ -194,6 +196,7 @@ class AionAuth(object):
                 continue
             ui_match = (ui_port is None)
             stcapi_url = None
+            tc_plus_url = None
             for p in inst.get('ports', []):
                 http = p.get('http', {})
                 name = p.get('name', '').lower()
@@ -201,18 +204,23 @@ class AionAuth(object):
                     ui_match = True
                 if name == 'stcapi':
                     stcapi_url = http.get('url', '')
-            if not ui_match or not stcapi_url:
+                if name == 'testcenterplus':
+                    tc_plus_url = http.get('url', '')
+            # TC+ routes /stcapi/sessions through its nginx (testcenterplus port).
+            # Prefer TC+'s URL so session management in TC+ is not bypassed.
+            resolved_url = tc_plus_url or stcapi_url
+            if not ui_match or not resolved_url:
                 continue
-            parsed = urlparse(stcapi_url)
+            parsed = urlparse(resolved_url)
             proto = parsed.scheme
             host = parsed.hostname
             port = parsed.port
             if not proto or not host or not port:
                 raise AionError(
-                    'stcapi port entry has invalid url: %s' % stcapi_url)
+                    'stcapi port entry has invalid url: %s' % resolved_url)
             if self._dbg_print:
                 print('===> stcapi endpoint: %s://%s:%d' % (proto, host, port))
-            return proto, host, port
+            return proto, host, port, (tc_plus_url is not None)
         if node_name is not None and ui_port is not None:
             raise AionError(
                 'no stcapi port entry found for node_name %s, ui_port %d' % (node_name, ui_port))

--- a/stcrestclient/aionstchttp.py
+++ b/stcrestclient/aionstchttp.py
@@ -101,7 +101,7 @@ class AionStcHttp(StcHttp):
         self._auth.login(username, password)
 
         # Discover stcapi proto/host/port from AION inventory
-        proto, host, port = self._auth.get_stcapi_endpoint(node_name=node_name, ui_port=ui_port)
+        proto, host, port, _ = self._auth.get_stcapi_endpoint(node_name=node_name, ui_port=ui_port)
 
         # Initialise StcHttp -- proto/host/port from inventory, token injected into base headers
         super(AionStcHttp, self).__init__(


### PR DESCRIPTION
## Problem

When using `AionStcHttp` to connect to a **TestCenter+** instance, the AION inventory lists two stcapi-related ports for that instance:
- `testcenterplus` — the TC+ port that routes session management through TC+'s own session layer
- `stcapi` — the raw labserver stcapi port, bypassing TC+

Previously, `AionStcHttp` always resolved to the raw `stcapi` port regardless of which instance was being connected to. This meant sessions created via the REST client went directly to the labserver and were invisible to TC+ — breaking session reconnect from AION Recent Activities, session tracking in the TC+ UI, and any feature that depends on TC+ knowing about active sessions.

## Changes

### `aionauth.py` — `get_stcapi_endpoint()`

- When connecting to a **TC+ instance**: discovery now detects the `testcenterplus` port in AION inventory and uses it, so all session management flows through TC+.
- When connecting to a **bare AION labserver** (no TC+): `testcenterplus` port is not present in inventory, so it falls back to the raw `stcapi` port — **same behaviour as before, no change**.

### `aionstchttp.py`

- Updated to unpack the new return value from `get_stcapi_endpoint`.

## Endpoint Routing Behaviour

| Connecting to | Port used | Session visible in TC+ UI |
|---|---|---|
| TC+ instance | `testcenterplus` (e.g. 64018) | Yes |
| Bare AION labserver | `stcapi` (direct labserver) | N/A |

## Testing

Tested end-to-end against an AION instance with TC+ using `AionStcHttp`:

- [x] Discovery resolves to the `testcenterplus` port (confirmed via `debug_print=True`)
- [x] Session created successfully and visible in the TC+ UI
- [x] Chassis connect, port create and attach
- [x] L2/L3 interface configuration and streamblock creation
- [x] Traffic run (10s, 10% line rate) with Tx/Rx counter verification
- [x] Session cleanup (`end_session`)
- [x] Bare AION labserver (no TC+) — falls back correctly to raw `stcapi` port, behaviour unchanged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Viavi-TestCenter/py-stcrestclient/39)
<!-- Reviewable:end -->
